### PR TITLE
Fix indentation near order book depth block

### DIFF
--- a/src/streamlit_app.py
+++ b/src/streamlit_app.py
@@ -347,10 +347,13 @@ collect_ob = st.sidebar.checkbox(
     "Собирать стакан (order book)?",
     default_fetch.get("collect_order_book", False)
 )
+
 order_book_depth = st.sidebar.selectbox(
     "Depth",
     [5, 10, 20, 50],
-    index=[5, 10, 20, 50].index(default_fetch.get("order_book_depth", 5))
+    index=[5, 10, 20, 50].index(
+        default_fetch.get("order_book_depth", 5)
+    ),
 )
 
 # Настройки симуляции


### PR DESCRIPTION
## Summary
- format the `order_book_depth` selectbox call for clarity

## Testing
- `python3 -m py_compile src/streamlit_app.py`

------
https://chatgpt.com/codex/tasks/task_e_684052cd9708832eab856ee7b831ce44