### PR TITLE
Set EUR/USD as default symbol

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# Algorithmic Trading Dashboard
+
+This project provides a Streamlit dashboard for collecting market data, generating features, backtesting strategies and running live trading.
+
+## Symbol Format
+
+Currency pairs should be specified with a slash separator, e.g. `EUR/USD`.

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -9,7 +9,8 @@ default_fetch:
   end_date: '2025-01-01'
   order_book_depth: 5
   start_date: '2024-01-01'
-  symbol: EURUSD
+  # Symbol should include a slash, e.g. "EUR/USD"
+  symbol: EUR/USD
   timeframe: M5
 indicators:
   adx:

--- a/config/plugins_config.json
+++ b/config/plugins_config.json
@@ -6,7 +6,7 @@
   "strategies": [],
   "strategies_params": {},
   "default_fetch": {
-    "symbol": "EURUSD",
+    "symbol": "EUR/USD",
     "timeframe": "M5",
     "start_date": "2024-01-01",
     "end_date": "2025-01-01",

--- a/src/streamlit_app.py
+++ b/src/streamlit_app.py
@@ -86,7 +86,7 @@ if st.sidebar.button("Сохранить настройки"):
 if st.sidebar.button("Проверить API"):
     try:
         _ = data_fetcher.get_historical_data(
-            symbol="EURUSD", timeframe="M1", start="2025-01-01", end="2025-01-02"
+            symbol="EUR/USD", timeframe="M1", start="2025-01-01", end="2025-01-02"
         )
         st.sidebar.success("API доступен, данные получены.")
     except Exception as e:
@@ -329,7 +329,8 @@ st.sidebar.subheader("Дефолты: Данные/Симуляция/Бэкте
 # Настройки fetch
 default_fetch = cfg.setdefault("default_fetch", {})
 symbol = st.sidebar.text_input(
-    "Symbol", default_fetch.get("symbol", "EURUSD")
+    "Symbol", default_fetch.get("symbol", "EUR/USD")
+    # Use slash format like "EUR/USD"
 )
 timeframe = st.sidebar.selectbox(
     "Timeframe",


### PR DESCRIPTION
## Summary
- set `EUR/USD` as the default symbol in project configuration files
- update Streamlit app to use `EUR/USD` when verifying API availability and as sidebar default
- document the required symbol format

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6840665dd224832e9af6949c3cec1309