### PR TITLE
Add test setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,13 @@ This project provides a Streamlit dashboard for collecting market data, generati
 ## Symbol Format
 
 Currency pairs should be specified with a slash separator, e.g. `EUR/USD`.
+
+## Running Tests
+
+Use the `run_tests.sh` script to install the minimal dependencies required for
+the test suite. The script upgrades `pip`, installs packages listed in
+`requirements-test.txt`, and then launches `pytest`.
+
+```bash
+./run_tests.sh
+```

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,2 @@
+requests
+pandas

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Simple helper for CI/devs: install minimal test requirements and run pytest
+set -e
+python -m pip install --upgrade pip
+python -m pip install -r requirements-test.txt
+pytest -q


### PR DESCRIPTION
## Summary
- document how to run tests
- add a helper script that installs packages needed by pytest

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68409a9f0af0832eae5470ac00b2dcca